### PR TITLE
Fixes issue when using remote workdir

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -428,7 +428,7 @@ if (!params.Q2imported){
 			set val(pair_id), file(reads) from ch_read_pairs
 		
 			output:
-			file "trimmed/*.*" into (ch_fastq_trimmed, ch_fastq_trimmed_manifest)
+			file "trimmed/*.*" into (ch_fastq_trimmed, ch_fastq_trimmed_manifest, ch_fastq_trimmed_qiime)
 			file "cutadapt_log_*.txt" into ch_fastq_cutadapt_log
 
 			script:
@@ -453,7 +453,7 @@ if (!params.Q2imported){
 			set val(pair_id), file(reads), val(folder) from ch_read_pairs
 		
 			output:
-			file "trimmed/*.*" into (ch_fastq_trimmed, ch_fastq_trimmed_manifest)
+			file "trimmed/*.*" into (ch_fastq_trimmed, ch_fastq_trimmed_manifest, ch_fastq_trimmed_qiime)
 			file "cutadapt_log_*.txt" into ch_fastq_cutadapt_log
 
 			script:
@@ -531,6 +531,7 @@ if (!params.Q2imported){
 			input:
 			file(manifest) from ch_manifest
 			env MATPLOTLIBRC from ch_mpl_for_qiime_import
+			file('*') from ch_fastq_trimmed_qiime.collect()
 
 			output:
 			file "demux.qza" into (ch_qiime_demux_import, ch_qiime_demux_vis, ch_qiime_demux_dada)
@@ -541,6 +542,16 @@ if (!params.Q2imported){
 			script:
 			if (!params.phred64) {
 				"""
+				head -n 1 ${manifest} > header.txt
+				tail -n+2 ${manifest} | cut -d, -f1 > col1.txt
+				tail -n+2 ${manifest} | cut -d, -f2 | sed 's:.*/::' > col2.txt
+				while read f; do
+					realpath \$f >> full_path.txt
+				done <col2.txt
+				tail -n+2 ${manifest} | cut -d, -f3 > col3.txt
+				paste -d, col1.txt full_path.txt col3.txt > cols.txt
+				cat cols.txt >> header.txt && mv header.txt ${manifest}
+
 				qiime tools import \
 					--type 'SampleData[PairedEndSequencesWithQuality]' \
 					--input-path ${manifest} \
@@ -549,6 +560,16 @@ if (!params.Q2imported){
 				"""
 			} else {
 				"""
+				head -n 1 ${manifest} > header.txt
+				tail -n+2 ${manifest} | cut -d, -f1 > col1.txt
+				tail -n+2 ${manifest} | cut -d, -f2 | sed 's:.*/::' > col2.txt
+				while read f; do
+					realpath \$f >> full_path.txt
+				done <col2.txt
+				tail -n+2 ${manifest} | cut -d, -f3 > col3.txt
+				paste -d, col1.txt full_path.txt col3.txt > cols.txt
+				cat cols.txt >> header.txt && mv header.txt ${manifest}
+
 				qiime tools import \
 					--type 'SampleData[PairedEndSequencesWithQuality]' \
 					--input-path ${manifest} \
@@ -567,6 +588,7 @@ if (!params.Q2imported){
 
 			input:
 			set file(manifest), env(MATPLOTLIBRC) from ch_manifest
+			file('*') from ch_fastq_trimmed_qiime.collect()
 
 			output:
 			file "*demux.qza" into (ch_qiime_demux_import, ch_qiime_demux_vis, ch_qiime_demux_dada) mode flatten
@@ -578,6 +600,16 @@ if (!params.Q2imported){
 			def folder = "${manifest}".take("${manifest}".indexOf("${params.split}"))
 			if (!params.phred64) {
 				"""
+				head -n 1 ${manifest} > header.txt
+				tail -n+2 ${manifest} | cut -d, -f1 > col1.txt
+				tail -n+2 ${manifest} | cut -d, -f2 | sed 's:.*/::' > col2.txt
+				while read f; do
+					realpath \$f >> full_path.txt
+				done <col2.txt
+				tail -n+2 ${manifest} | cut -d, -f3 > col3.txt
+				paste -d, col1.txt full_path.txt col3.txt > cols.txt
+				cat cols.txt >> header.txt && mv header.txt ${manifest}
+
 				qiime tools import \
 					--type 'SampleData[PairedEndSequencesWithQuality]' \
 					--input-path ${manifest} \
@@ -586,6 +618,16 @@ if (!params.Q2imported){
 				"""
 			} else {
 				"""
+				head -n 1 ${manifest} > header.txt
+				tail -n+2 ${manifest} | cut -d, -f1 > col1.txt
+				tail -n+2 ${manifest} | cut -d, -f2 | sed 's:.*/::' > col2.txt
+				while read f; do
+					realpath \$f >> full_path.txt
+				done <col2.txt
+				tail -n+2 ${manifest} | cut -d, -f3 > col3.txt
+				paste -d, col1.txt full_path.txt col3.txt > cols.txt
+				cat cols.txt >> header.txt && mv header.txt ${manifest}
+
 				qiime tools import \
 					--type 'SampleData[PairedEndSequencesWithQuality]' \
 					--input-path ${manifest} \


### PR DESCRIPTION
This PR fixes the issue when using a remote working directory in the `qiime_import` process by:
- Staging the FASTQ files into the `qiime_import` process
- Modifying the `manifest.txt` file in this process to use the `realpath` of the files (& not just the paths in the working directory as when this is remote the files cannot be found)
